### PR TITLE
Encapsulate ReduxibleConfig.

### DIFF
--- a/src/Reduxible.js
+++ b/src/Reduxible.js
@@ -2,17 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 import ReduxibleRouter from './ReduxibleRouter';
+import ReduxibleConfig from './Reduxibleconfig';
 import StoreFactory from './StoreFactory';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import createMemoryHistory from 'history/lib/createMemoryHistory';
 
 export default class Reduxible {
   constructor(options = {}) {
-    this.config = options.config;
+    this.config = new ReduxibleConfig(options.config);
     this.container = options.container;
     this.errorContainer = options.errorContainer;
     this.routes = options.routes;
-    this.storeFactory = new StoreFactory({ ...options });
+    this.storeFactory = new StoreFactory({ ...options, config: this.config });
     this.extras = options.extras;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
 import Reduxible from './Reduxible';
-import ReduxibleConfig from './ReduxibleConfig';
 
-export { ReduxibleConfig };
 export default Reduxible;


### PR DESCRIPTION
I think this approach is much better. 
on the user side, just passing config object instead of `ReduxibleConfig` instance.
